### PR TITLE
fix: remove padding top from equipes e ranking page

### DIFF
--- a/src/app/equipes-e-ranking/page.tsx
+++ b/src/app/equipes-e-ranking/page.tsx
@@ -5,7 +5,7 @@ import ImageG from '@/components/ImageG'
 
 export default function EquipesERanking() {
     return (
-        <main className='pt-24'>
+        <main>
             <ImageG className='w-full -mb-1 pointer-events-none rotate-180' src='home/onda_branca.svg' width="1280" height="186" alt='Onda branca' />
             <Equipes />
             <ImageG id="ranking" className='w-full -mt-1 pointer-events-none' src='home/onda_branca.svg' width="1280" height="186" alt='Onda branca' />


### PR DESCRIPTION
# ✨ Pull Request 💻


## :dart: Detalhes do Pull Request:

Remove o paddin-top desnecessário na página de equipes e ranking

Fixes #84 

##  :camera_flash: Screenshots:
![image](https://github.com/user-attachments/assets/8c49058b-1ffc-4733-bf5d-52606b5c2a3e)

