### PR TITLE
Padronizar margin e padding

### DIFF
--- a/src/app/components/Etapas.tsx
+++ b/src/app/components/Etapas.tsx
@@ -66,7 +66,7 @@ interface EtapasProps {
 const Etapas: React.FC<EtapasProps> = ({ etapas }) =>{
 
     return (
-        <section className="grid grid-cols-1 lg:grid-cols-2 md:flex-row justify-center bg-brancoBX py-8">
+        <section className="grid grid-cols-1 lg:grid-cols-2 md:flex-row justify-center bg-brancoBX pb-16">
             <header className="m-4 md:m-16">
                 <h1 className="text-verdeBX text-6xl mb-4">Etapas</h1>
                 <h2 className={`${poppins.className} text-black text-thin`}>Estude ao rever os temas, desafios e resoluções já apresentadas nesta edição do BXCOMP!</h2>

--- a/src/app/o-que-e-bxcomp/page.tsx
+++ b/src/app/o-que-e-bxcomp/page.tsx
@@ -25,7 +25,7 @@ function Descricao() {
 	return (
 		<section>
 			<div className="lg:px-32">
-				<h1 className="text-6xl sm:text-6xl py-4 sm:py-8">
+				<h1 className="mt-12 mb-8 text-6xl">
 					O que é o <span className="text-laranjaBX">BXComp</span>?
 				</h1>
 
@@ -158,7 +158,7 @@ const OrganizadorCard: React.FC<OrganizadorCardProps> = ({ organizador }) => {
 function Organizadores() {
 	return (
 		<section className="flex flex-col items-center justify-center my-20">
-			<h1 className="text-6xl text-laranjaBX sm:text-6xl py-4 sm:py-8 text-center">
+			<h1 className="text-6xl text-laranjaBX sm:text-6xl pb-4 sm:pb-8 text-center">
 				Organizadores
 			</h1>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
       <Equipes equipes={equipesData}/>
 
         <figure className="relative w-full bg-pretoBX pointer-events-none">
-          <Image className="hidden md:block absolute right-12 -bottom-8" src="/home/gravityfalls.png" alt="" width="281" height="312" /> 
+          <Image className="hidden md:block absolute right-12 -bottom-12" src="/home/gravityfalls.png" alt="" width="281" height="312" /> 
           <Image
             src="/home/onda_branca.svg"
             alt="Onda branca"

--- a/src/components/Equipes.tsx
+++ b/src/components/Equipes.tsx
@@ -34,7 +34,7 @@ const Equipes: React.FC<EquipesProps> = ({equipes}) => {
     }
     
     return (
-    <section className="pb-8 pt-16 sm:px-24 bg-brancoBX grid grid-cols-1 lg:grid-cols-2 justify-center padding">
+    <section className="pt-16 sm:px-24 bg-brancoBX grid grid-cols-1 lg:grid-cols-2 justify-center padding">
     
         {/* parte que mostra os botões de todas as equipes */}
         <section className="order-2 lg:order-1 my-4 md:my-2 py-2 md:px-8 lg:px-0 flex flex-wrap items-center justify-center">
@@ -67,7 +67,7 @@ const Equipes: React.FC<EquipesProps> = ({equipes}) => {
             </section>
             
             {/* Onda laranja de baixo do circulo que apresenta equipe e membros da equipe */}
-            <div className="relative z-20 mb-8 -mt-16 pt-2 pb-6 sm:pb-4 drop-shadow-md bg-laranjaBX w-full max-w-80 h-fit md:h-52 md:w-80 rounded-tl-[96px] rounded-br-[96px] flex flex-col items-center justify-center">
+            <div className="relative z-20 -mt-16 pt-2 pb-6 sm:pb-4 drop-shadow-md bg-laranjaBX w-full max-w-80 h-fit md:h-52 md:w-80 rounded-tl-[96px] rounded-br-[96px] flex flex-col items-center justify-center">
                 <h2 className={`${lilita.className} text-center px-2 break-words w-48 sm:w-60 my-1 mt-3 sm:my-2 text-md tracking-wide drop-shadow-md text-2xl font-bold`}> {equipes[idSelecionado].nome} </h2>
                 <div className={`${poppins.className} text-center w-full max-w-[18rem] flex flex-col items-center justify-center text-sm text-white`}>
                     {equipes[idSelecionado].membros.map((membro, idx) => {


### PR DESCRIPTION
Issue #103

Padronizar padding em todas as pags

Padronizar parágrafos

 Padronizar padding superior para os headings h1 (FEITO)
 
 Padronizar distâncias entre seções na página inicial ex: a seção de Etapas e Desafios está muito para baixo, muito separada da hero section, assim como a seção de Ranking está muito separada da seção de equipes. (FEITO mais ou menos, preciso que alguém revise pra dizer que tá bom)